### PR TITLE
fix tests to work when UNIVERSAL has an import method

### DIFF
--- a/t/204-T-Basic-all.t
+++ b/t/204-T-Basic-all.t
@@ -116,7 +116,7 @@ $report = refute_and_report {
     can_ok current_contract, "frobnicate";
     can_ok "Assert::Refute", "import", "can_ok";
     can_ok "Assert::Refute", "unknown_subroutine";
-    can_ok "No::Exist", "can", "isa", "import";
+    can_ok "No::Exist", "can", "isa", "unknown_subroutine";
 };
 is $report->get_sign, "t1N1NNd", "can_ok()";
 note $report->get_tap;


### PR DESCRIPTION
Future versions of perl are intending to add a real import method to UNIVERSAL. The tests had been assuming that checking for import would fail. Stop testing for import, and test for a method that will never exist.